### PR TITLE
jpcoar2.0の統制語彙から抜けがあったので追加

### DIFF
--- a/app/modules/depositor_item_register/depositor_item_register/utils.py
+++ b/app/modules/depositor_item_register/depositor_item_register/utils.py
@@ -64,6 +64,16 @@ namespace_list={"jpcoar2.0":{
     "xsi:schemaLocation":"https://github.com/JPCOAR/schema/blob/master/2.0/ jpcoar_scm.xsd"
 }}
 
+# xml用タグ判別用
+tag_list = {"jpcoar2.0":[
+    "jpcoar",
+    "datacite",
+    "dc",
+    "dcterms"
+    ]
+}
+
+
 # xml用roottag設定用
 root_tag={"jpcoar2.0":"jpcoar:jpcoar"}
 
@@ -77,6 +87,10 @@ def dicttoxmlforsword(kindofproperty, item_metadata):
                     # リストに対応するキーとキーが一致するならそれは値
                     if proper_key==property_key:
                         child.text = proper_value
+                    # キーとキーが一致しないが、taglistと合致するならこれも値
+                    elif proper_key.split(":")[0] in tag_list.get(kindofproperty,"") :
+                        grandchild = ET.SubElement(child, proper_key)
+                        grandchild.text = proper_value
                     # リストに対応するキーでないならそれは属性
                     else:
                         child.set(proper_key, proper_value)

--- a/app/modules/depositor_item_register/depositor_item_register/utils.py
+++ b/app/modules/depositor_item_register/depositor_item_register/utils.py
@@ -9,6 +9,7 @@ metadata_list ={
         "dc:title",
         "dcterms:alternative",
         "jpcoar:creator",
+        "jpcoar:contributor",
         "dcterms:accessRights",
         "dc:rights",
         "jpcoar:rightsHolder",

--- a/app/modules/depositor_item_register/tests/test_utils.py
+++ b/app/modules/depositor_item_register/tests/test_utils.py
@@ -10,6 +10,27 @@ def test_dicttoxmlforsword():
             "dc:type": "data paper",
             "rdf:resource": "http://purl.org/coar/resource_type/c_beb9"
         }],
+    "datacite:geoLocation":[{
+        "datacite:geoLocationPoint": [
+            {
+                "datacite:pointLongitude": "経度",
+                "datacite:pointLatitude": "緯度"
+            }
+        ],
+        "datacite:geoLocationBox": [
+            {
+                "datacite:westBoundLongitude": "西部経度",
+                "datacite:eastBoundLongitude": "東部経度",
+                "datacite:southBoundLongitude": "南部緯度",
+                "datacite:northBoundLongitude": "北部緯度"
+            }
+        ],
+        "datacite:geoLocationPlace": [
+            {
+                "datacite:geoLocationPlace": "位置情報（自由記述）"
+            }
+        ]
+    }],
     "jpcoar:file":[{
         "filename": "metadata.pdf",
         "jpcoar:mimeType": "application/pdf",
@@ -29,4 +50,4 @@ def test_dicttoxmlforsword():
     }]
     }
     result = dicttoxmlforsword("jpcoar2.0", test_data).decode("utf-8")
-    assert result == '<jpcoar:jpcoar xmlns:jpcoar="https://github.com/JPCOAR/schema/blob/master/2.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:datacite="https://schema.datacite.org/meta/kernel-4/" xmlns:oaire="http://namespace.openaire.eu/schema/oaire/" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/JPCOAR/schema/blob/master/2.0/ jpcoar_scm.xsd"><dc:title xml:lang="fr">test</dc:title><dc:type rdf:resource="http://purl.org/coar/resource_type/c_beb9">data paper</dc:type><jpcoar:file filename="metadata.pdf" jpcoar:mimeType="application/pdf"><jpcoar:URI label="metadata.pdf" objectType="other">data/contentfiles/metadata.pdf</jpcoar:URI><jpcoar:extent>1 KB</jpcoar:extent></jpcoar:file></jpcoar:jpcoar>'
+    assert result == '<jpcoar:jpcoar xmlns:jpcoar="https://github.com/JPCOAR/schema/blob/master/2.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:datacite="https://schema.datacite.org/meta/kernel-4/" xmlns:oaire="http://namespace.openaire.eu/schema/oaire/" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/JPCOAR/schema/blob/master/2.0/ jpcoar_scm.xsd"><dc:title xml:lang="fr">test</dc:title><dc:type rdf:resource="http://purl.org/coar/resource_type/c_beb9">data paper</dc:type><datacite:geoLocation><datacite:geoLocationPoint><datacite:pointLongitude>経度</datacite:pointLongitude><datacite:pointLatitude>緯度</datacite:pointLatitude></datacite:geoLocationPoint><datacite:geoLocationBox><datacite:westBoundLongitude>西部経度</datacite:westBoundLongitude><datacite:eastBoundLongitude>東部経度</datacite:eastBoundLongitude><datacite:southBoundLongitude>南部緯度</datacite:southBoundLongitude><datacite:northBoundLongitude>北部緯度</datacite:northBoundLongitude></datacite:geoLocationBox><datacite:geoLocationPlace>位置情報（自由記述）</datacite:geoLocationPlace></datacite:geoLocation><jpcoar:file filename="metadata.pdf"><jpcoar:mimeType>application/pdf</jpcoar:mimeType><jpcoar:URI label="metadata.pdf" objectType="other">data/contentfiles/metadata.pdf</jpcoar:URI><jpcoar:extent>1 KB</jpcoar:extent></jpcoar:file></jpcoar:jpcoar>'

--- a/app/static/json/form.json
+++ b/app/static/json/form.json
@@ -4482,6 +4482,10 @@
                                 "value": "Crossref Funder"
                             },
                             {
+                                "name":"e-Rad_funder",
+                                "value":"e-Rad_funder"
+                            },
+                            {
                                 "name": "GRID",
                                 "value": "GRID"
                             },
@@ -8567,7 +8571,17 @@
             },
             {
                 "key": "jpcoar:file[].jpcoar:mimeType",
-                "type": "text",
+                "items":[
+                    {
+                        "key":"jpcoar:file[].jpcoar:mimeType[].jpcoar:mimeType",
+                        "type": "text",
+                        "title": "フォーマット",
+                        "title_i18n": {
+                            "en": "Format",
+                            "ja": "フォーマット"
+                        }
+                    }
+                ],
                 "title": "フォーマット",
                 "title_i18n": {
                     "en": "Format",

--- a/app/static/json/form.json
+++ b/app/static/json/form.json
@@ -4403,7 +4403,7 @@
                         }
                     },
                     {
-                        "key": "datacite:geoLocation[].datacite:geoLocationBox.datacite:southBoundLongitude",
+                        "key": "datacite:geoLocation[].datacite:geoLocationBox.datacite:southBoundLatitude",
                         "type": "text",
                         "title": "南部緯度",
                         "title_i18n": {
@@ -4412,7 +4412,7 @@
                         }
                     },
                     {
-                        "key": "datacite:geoLocation[].datacite:geoLocationBox.datacite:northBoundLongitude",
+                        "key": "datacite:geoLocation[].datacite:geoLocationBox.datacite:northBoundLatitude",
                         "type": "text",
                         "title": "北部緯度",
                         "title_i18n": {

--- a/app/static/json/form.json
+++ b/app/static/json/form.json
@@ -2219,7 +2219,7 @@
                         }
                     },
                     {
-                        "key": "jpcoar:rightsHolder[].rightHolderNames[].rightHolderName",
+                        "key": "jpcoar:rightsHolder[].jpcoar:rightsHolderName[].jpcoar:rightsHolderName",
                         "type": "text",
                         "title": "権利者名",
                         "title_i18n": {

--- a/app/static/json/jsonschema.json
+++ b/app/static/json/jsonschema.json
@@ -10,7 +10,7 @@
         "file_name": "jpcoar:file[].filename",
         "file_url": "jpcoar:file[].jpcoar:URI[0].jpcoar:URI",
         "file_label": "jpcoar:file[].jpcoar:URI[0].label",
-        "file_format": "jpcoar:file[].jpcoar:mimeType",
+        "file_format": "jpcoar:file[].jpcoar:mimeType[0].jpcoar:mimeType",
         "file_size": "jpcoar:file[].jpcoar:extent[0].jpcoar:extent",
         "file_type": "jpcoar:file[].jpcoar:URI[0].objectType"
     },


### PR DESCRIPTION
・jpcoar2.0の統制語彙から抜けがあったので追加
・xml化するキーリストからjpcoar:contributorが抜けていたため追加します。
・権利者情報＞権利者名のjsonschemaが間違っていたため修正します。
・xml化する際、キーとキーが一致しなくても値をなる場合を処理できていなかったのでその処理を追加します。
・スキーマのキーのスペルが間違っていたので修正します。
・バグ修正に伴う単体テストコード修正です。